### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,19 @@
-###Introduction
+### Introduction
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/hewigovens/packageuninstaller/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 It's really annoying that Apps installed by pkg files don't provide a way to uninstall them. Package Uninstaller is kind of Proof of Concept to solve this problem. It will list all your installer receipts and you can uninstall them with just one click.
 
-###Why not CleanMyMac/AppZapper...?
+### Why not CleanMyMac/AppZapper...?
 
 * for fun
 * different focus, Package Uninstaller focus on apps installed by Apple Installer.
 
-###ScreenShot
+### ScreenShot
 
 <img src="doc/overview.png">
 
-###Build
+### Build
 
 * `git submodule update --init`
 * Create a Self Signed Root/Code Signing named "Developer ID Application: In House Only" from KeyChain Acess.app
@@ -22,20 +22,20 @@ It's really annoying that Apps installed by pkg files don't provide a way to uni
 * * key `SMAuthorizedClients` in `PackageUninstallerHelper-Info.plist`
 * Open `PackageUninstaller.xcodeproj`, Click Product -> Archive
 
-###Downloads
+### Downloads
 
 Download from [sourceforge](http://sourceforge.net/projects/packageuninstaller/files/latest/download)
 
-###TODO
+### TODO
 
 * hook Apple Installer to support uninstall apps like MS Office.
 * * pkg files are abused in MS Office.
 * * Please go [How to completely remove Office for Mac 2011](http://support.microsoft.com/kb/2398768) for help, :)
 
-###Credit
+### Credit
 * Icon designed by Nikolay Verin - [http://ncrow.deviantart.com/](http://ncrow.deviantart.com/)
 * launchctl from [opensource.apple.com](http://www.opensource.apple.com/source/launchd/launchd-442.26.2/)
 
-###License
+### License
 
 The MIT License (MIT)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
